### PR TITLE
Add package test to docker build pipeline

### DIFF
--- a/{{ cookiecutter.name }}/buildkite/pipeline.yml
+++ b/{{ cookiecutter.name }}/buildkite/pipeline.yml
@@ -4,8 +4,8 @@ steps:
 
   - wait
 
-  - label: ":docker: Docker connection test"
-    command: docker/test_connection
+  - label: ":docker: Test package installed"
+    command: docker/test_package
 
   - wait
 

--- a/{{ cookiecutter.name }}/docker/test_package
+++ b/{{ cookiecutter.name }}/docker/test_package
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -ex
+HERE=$(dirname $0)
+. $HERE/common
+
+docker run --rm \
+       --workdir /src \
+       $TAG_SHA \
+       Rscript -e "library($PACKAGE_NAME)"


### PR DESCRIPTION
Noticed this when working on Kelp stuff. We call `test_connection` but the script doesn't exist. I've updated this to `test_package` and added that as a best script which checks the package is installed inside the docker container.