### PR TITLE
Add post gen hook to print prompt for user about turning on CodeFactor

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,3 @@
+
+print("\x1b[1;33mGeneration complete\x1b[0m")
+print("To run lintr on CI turn on CodeFactor for this repo at https://www.codefactor.io/repository/new")


### PR DESCRIPTION
Ticket is about adding .lintr setup to the package but that already exists. I think I must have missed it when I created the ticket, this PR will just print a message to the user to prompt them to turn CodeFactor on.

I'm thinking we can also use the post hook in future to remove certain files e.g. docker build when we don't need them e.g. 

```
def remove_docker_files():
    """
    Removes files needed for docker if it isn't going to be used
    """
    for filename in ["docker",]:
        os.remove(os.path.join(
            PROJECT_DIRECTORY, filename
        ))

if '{{ cookiecutter.use_docker }}'.lower() != 'y':
    remove_docker_files()
```
but in another ticket